### PR TITLE
Changed spsdk_keyfactor to use PSS padding

### DIFF
--- a/keyfactor/README.md
+++ b/keyfactor/README.md
@@ -33,9 +33,9 @@ All of plugin configuration can be done via environment variables:
 - `KEYFACTOR_AUTH_VALUE`: Coma-separated string of values described by `KEYFACTOR_AUTH_TYPE` (example for PKCS#12: "path_to_pkcs.p12,path_to_pass.txt")
 - `KEYFACTOR_WORKER`: Name or ID of the Keyfactor Worker to use (example: "PlainSigner")
 - `KEYFACTOR_PREHASH`: Client-side pre-hashing of data  (example: "NONE", "SHA-256")
-    - if this setting is skipped, the plugin will autodetect the value
+    - This setting cannot be autodetected and must be provided
 - `KEYFACTOR_SIGNATURE_LENGTH`: Length in bytes of the raw signature (without potential DER encoding) (example: 256 for RSA, 64 for ECC-256)
-    - if this setting is skipped, the plugin will autodetect the value
+    - This setting cannot be autodetected and must be provided
 
 Environment variables may be specified in a file.
 By default the plugin searches for file named `.keyfactor.env` in the following locations: `CWD`, `HOME`, `~/.config`  

--- a/keyfactor/spsdk_keyfactor/provider.py
+++ b/keyfactor/spsdk_keyfactor/provider.py
@@ -175,6 +175,10 @@ class KeyfactorSP(SignatureProvider):
             }
         else:
             data_out = data
+            payload["metaData"] = {
+                "USING_CLIENTSUPPLIED_HASH": "true",
+                "CLIENTSIDE_HASHDIGESTALGORITHM": self.prehash.name.upper(),
+            }
 
         payload["data"] = base64.b64encode(data_out).decode(encoding="utf-8")
 
@@ -195,7 +199,7 @@ class KeyfactorSP(SignatureProvider):
         )
         signature = base64.b64decode(response_data["data"])
 
-        if not self.signer_certificate.get_public_key().verify_signature(signature, data):
+        if not self.signer_certificate.get_public_key().verify_signature(signature, data, pss_padding=True):
             raise KeyfactorPluginError(
                 "Signature verification failed. Please check your KEYFACTOR_PREHASH settings."
             )


### PR DESCRIPTION
The original code did not account for PSS padding.  The Keyfactor configuration for PSS padding requires that the algorithm and key size be known beforehand.

This update is required to work with Keyfactor's PSS padding configuration.